### PR TITLE
로그인시 자동 새로고침, 유저 정보수정 페이지 마크업

### DIFF
--- a/src/api/pocketbase.js
+++ b/src/api/pocketbase.js
@@ -3,11 +3,17 @@ import PocketBase from "pocketbase";
 export const pb = new PocketBase(import.meta.env.VITE_PB_URL);
 pb.autoCancellation(false);
 
+const autoReload = pb.authStore.onChange((token, model) => {
+  globalThis.location.reload()
+})
+
+//콜랙션에 데이터값으로 아이템 생성 
 export async function create(collection, data) {
   const create = await pb.collection(collection).create(data);
   return create;
 }
 
+//콜랙션 읽기, 필드값을 추가하면 필터링 됨 
 export async function read(collection, field, id) {
   const FieldData = await pb.collection(collection).getList(1, 10, {
     fields: field,
@@ -16,6 +22,7 @@ export async function read(collection, field, id) {
   return field ? FieldData : collectionData;
 }
 
+//콜랙션 전부 읽기 
 export async function fullRead(collection, field, id) {
   const FieldData = await pb.collection(collection).getFullList({
     fields: field,
@@ -24,16 +31,19 @@ export async function fullRead(collection, field, id) {
   return field ? FieldData : collectionData;
 }
 
+//콜랙션의 아이템에 데이터를 업데이트, 데이터는 객체이며 키값이 일치해야 한다 
 export function update(collection, itemId, data) {
   const update = pb.collection(collection).update(itemId, data);
   return update;
 }
 
+//로그인 
 export async function setLogIn(idPw) {
   const authData = await pb.collection("users").authWithPassword(...idPw);
   return authData;
 }
 
+//로그아웃 
 export function setLogOut() {
   pb.authStore.clear();
 }

--- a/src/api/pocketbase.js
+++ b/src/api/pocketbase.js
@@ -31,7 +31,7 @@ export async function fullRead(collection, field, id) {
   return field ? FieldData : collectionData;
 }
 
-//콜랙션의 아이템에 데이터를 업데이트, 데이터는 객체이며 키값이 일치해야 한다 
+//콜랙션의 아이템에 데이터를 업데이트, 데이터는 객체이며 해당 콜랙션의 필드와 키값이 일치해야 한다 
 export function update(collection, itemId, data) {
   const update = pb.collection(collection).update(itemId, data);
   return update;

--- a/src/components/SignInUp/SignInput.jsx
+++ b/src/components/SignInUp/SignInput.jsx
@@ -1,7 +1,15 @@
 import { string, func } from "prop-types";
 import { useState } from "react";
 
-function SignInput({ labelValue, ariaText, placeHolder, inputValue }) {
+function SignInput({
+  labelValue,
+  ariaText,
+  placeHolder,
+  inputValue,
+  bgColor = "bg-primary",
+  textColor = "text-white",
+  placeHolderColor = "placeholder-white",
+}) {
   const [inputChange, setInputChange] = useState("");
 
   const handleChangeInput = ({ target }) => {
@@ -16,7 +24,7 @@ function SignInput({ labelValue, ariaText, placeHolder, inputValue }) {
       </label>
       <input
         id="signInputId"
-        className="w-full rounded border px-7 py-4 text-base text-white bg-primary placeholder-white"
+        className={`${textColor} ${bgColor} ${placeHolderColor} w-full rounded border px-7 py-4 text-base`}
         type="text"
         aria-label={ariaText}
         placeholder={placeHolder}
@@ -31,6 +39,9 @@ SignInput.propTypes = {
   ariaText: string,
   placeHolder: string,
   inputValue: func,
+  bgColor: string,
+  textColor: string,
+  placeHolderColor: string,
 };
 
 export default SignInput;

--- a/src/components/SignInUp/SignLogo.jsx
+++ b/src/components/SignInUp/SignLogo.jsx
@@ -1,7 +1,7 @@
 function SignLogo() {
   return (
     <div className="flex flex-col  self-center font-extrabold">
-      <img className="w-20 self-center" src="/public/logo.svg" alt="로고 이미지" />
+      <img className="w-20 self-center" src="/logo.svg" alt="로고 이미지" />
       <h1 className="text-2xl">Best Place</h1>
     </div>
   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { pb, setLogIn } from "@/api/pocketbase";
+import { pb, read, setLogIn } from "@/api/pocketbase";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -10,20 +10,24 @@ import SignLogo from "@c/SignInUp/SignLogo";
 import SignContents from "@c/SignInUp/SignContents";
 
 function Login() {
-  const navigate = useNavigate()
-  
+  const navigate = useNavigate();
+
   const [id, setId] = useState("");
   const [pw, setPw] = useState("");
   let idPw = [id, pw];
 
   console.log(idPw);
 
-  async function getIds(pb) {
-    const users = await pb.collection("users").getList(1, 99);
+  async function getIds() {
+    const users = read("users");
     const ids = users.items.map((item) => item.username);
-    return ids;
+    const isValidId = ids.include(id);
+    console.log(isValidId);
+    return isValidId;
   }
+
   function isId() {}
+
   return (
     <SignContents>
       <SignLogo />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,5 +1,6 @@
 import { pb, setLogIn } from "@/api/pocketbase";
 import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 
 import SignTitle from "@c/SignInUp/SignTitle";
 import SignInput from "@c/SignInUp/SignInput";
@@ -9,6 +10,8 @@ import SignLogo from "@c/SignInUp/SignLogo";
 import SignContents from "@c/SignInUp/SignContents";
 
 function Login() {
+  const navigate = useNavigate()
+  
   const [id, setId] = useState("");
   const [pw, setPw] = useState("");
   let idPw = [id, pw];
@@ -21,7 +24,6 @@ function Login() {
     return ids;
   }
   function isId() {}
-
   return (
     <SignContents>
       <SignLogo />
@@ -40,8 +42,7 @@ function Login() {
 
       <div className="flex flex-col gap-2">
         <SignButton value="로그인" handleEvent={() => setLogIn(idPw)} bgColor="bg-white" textColor="text-black" />
-        {/* <br /> */}
-        <SignButton value="회원가입(미완)" handleEvent={() => setLogIn(idPw)} />
+        <SignButton value="회원가입" handleEvent={() => navigate("/Register")} />
       </div>
     </SignContents>
   );

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -7,8 +7,11 @@ import SignForm from "@c/SignInUp/SignForm";
 import SignContents from "@c/SignInUp/SignContents";
 import { pb, read, create, update } from "@/api/pocketbase";
 import SignLogo from "@c/SignInUp/SignLogo";
+import { useNavigate } from "react-router-dom";
 
 function Register() {
+  const navigate = useNavigate();
+
   const [id, setId] = useState("");
   const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
@@ -40,7 +43,6 @@ function Register() {
     email: email,
     password: pw,
     passwordConfirm: pwCheck,
-
   };
   const updateData = {
     nickname: "업데이트된 닉네임",
@@ -73,14 +75,11 @@ function Register() {
           inputValue={setPwCheck}
         />
       </SignForm>
-      {/* <SignButton value="업데이트" handleEvent={() => update("users", pb.authStore.model.id, updateData)} /> */}
-      <SignButton
-        value="회원가입"
-        handleEvent={() => create("users", userData)}
-        bgColor="bg-white"
-        textColor="text-black"
-      />
-      {/* <SignButton value="아이디 목록" handleEvent={() => read("users")} /> */}
+
+      <div className="flex flex-col gap-2">
+        <SignButton value="회원가입" handleEvent={() => read()} bgColor="bg-white" textColor="text-black" />
+        <SignButton value="로그인" handleEvent={() => navigate("/Login")} />
+      </div>
     </SignContents>
   );
 }

--- a/src/pages/UpdateUserData.jsx
+++ b/src/pages/UpdateUserData.jsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { pb, read, update } from "@/api/pocketbase";
+import { useNavigate } from "react-router-dom";
+
+import SignTitle from "@c/SignInUp/SignTitle";
+import SignInput from "@c/SignInUp/SignInput";
+import SignButton from "@c/SignInUp/SignButton";
+import SignForm from "@c/SignInUp/SignForm";
+import SignContents from "@c/SignInUp/SignContents";
+import { produce } from "immer";
+import Profile from "./../components/Profile";
+
+function Register() {
+  const navigate = useNavigate();
+
+  const [nickname, setNickname] = useState();
+  const [avatar, setAvatar] = useState();
+  const [username, setUsername] = useState();
+
+  const UserDataFormat = {
+    id: "",
+    collectionName: "users",
+    collectionId: "_pb_users_auth_",
+    emailVisibility: false,
+    verified: false,
+    created: "2023-08-31 06:35:29.391Z",
+    updated: "2023-08-31 06:35:29.391Z",
+    follower: [],
+    following: [],
+    favorites: [],
+    review: [],
+    username: "id와 같음",
+    nickname: "별명",
+    email: "",
+    password: "",
+    passwordConfirm: "",
+    avatar: "",
+    regions: [],
+  };
+
+  const updateData = {
+    nickname: nickname,
+    username: username,
+    avatar: avatar,
+  };
+
+  return (
+    <div className="flex flex-col gap-20 py-10">
+      <SignTitle value="회원정보 업데이트" />
+
+      <SignForm>
+        <SignInput
+          labelValue="새 별명"
+          ariaText="이메일 입력창"
+          placeHolder="사용할 새 별명을 입력하세요"
+          inputValue={setNickname}
+          bgColor="bg-white"
+          textColor="text-black"
+          placeHolderColor="placeholder-black"
+        />
+        <SignInput
+          labelValue="새 프로필 사진"
+          ariaText="아이디 입력창"
+          placeHolder="클릭하면 사진입력하는 기능 추가할것"
+          inputValue={setAvatar}
+          bgColor="bg-white"
+          textColor="text-black"
+          placeHolderColor="placeholder-black"
+        />
+        <SignInput
+          labelValue="새 아이디"
+          ariaText="아이디 입력창"
+          placeHolder="로그인에 사용할 새 아이디"
+          inputValue={setUsername}
+          bgColor="bg-white"
+          textColor="text-black"
+          placeHolderColor="placeholder-black"
+        />
+      </SignForm>
+
+      <div className="flex gap-2">
+        <SignButton value="취소" handleEvent={() => navigate("/Feed")} bgColor="bg-white" textColor="text-red-600" />
+        <SignButton
+          value="수정완료"
+          handleEvent={() => update("users", pb.authStore.model.id, updateData)}
+          bgColor="bg-primary"
+          textColor="text-white"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Register;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -6,6 +6,7 @@ import Feed from "@p/Feed";
 import ReviewWrite from "@p/ReviewWrite";
 import Region from "@p/Region";
 import ReviewList from "@p/ReviewList";
+import UpdateUserData from "@p/UpdateUserData";
 import Login from "@p/Login";
 import Register from "@p/Register";
 
@@ -23,6 +24,7 @@ const routerConfig = isValidUser
           { path: "리뷰", element: <ReviewList /> },
           { path: "저장", element: <Region /> },
           { path: "feed", element: <Feed /> },
+          { path: "updateUserData", element: <UpdateUserData /> },
         ],
       },
     ]

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,15 +1,13 @@
 import { createBrowserRouter } from "react-router-dom";
+import { pb } from "@/api/pocketbase";
 import RootLayout from "@l/RootLayout";
 import NotFound from "@p/NotFound";
 import Feed from "@p/Feed";
 import ReviewWrite from "@p/ReviewWrite";
 import Region from "@p/Region";
 import ReviewList from "@p/ReviewList";
-import { pb } from "@/api/pocketbase";
-
-// import Login from "@p/Login";
-import Login from "@p/TestLogin";
-// import Login from "@p/Register";
+import Login from "@p/Login";
+import Register from "@p/Register";
 
 let isValidUser = pb.authStore.isValid;
 
@@ -31,7 +29,11 @@ const routerConfig = isValidUser
   : [
       {
         path: "/",
-        element: <Login />,
+        children: [
+          { index: true, element: <Login /> },
+          { path: "login", element: <Login /> },
+          { path: "register", element: <Register /> },
+        ],
       },
     ];
 


### PR DESCRIPTION
fix : 로고이미지 경로를 절대경로로 수정
feat : 로그인/회원가입 페이지 이동버튼 추가
feat : navigate 하기위해 비로그인 컴포넌트에 Register 추가
feat : 로그인시 자동 새로고침
comment : pocketbase.js 주석수정
add : 유저 정보수정 페이지 마크업
refactor : SignInUp 인풋 아토믹을 테일윈드 속성을 프롭으로 받을 수 있게 변경
refactor : 로그인 페이지에서 db 읽기를 read 함수를 가져다 쓰게 수정
modify : 라우터 컴포넌트에 updateUserData 페이지 추가
